### PR TITLE
fix: record missing when record count greater than 20

### DIFF
--- a/cloudflare_ddns/cloudflare.py
+++ b/cloudflare_ddns/cloudflare.py
@@ -112,7 +112,7 @@ class CloudFlare:
         self.zone = zone
 
         # Initialize dns_records of current zone
-        dns_content = self.request(self.api_url + zone['id'] + '/dns_records', 'get')
+        dns_content = self.request(self.api_url + zone['id'] + '/dns_records?per_page=100', 'get')
         self.dns_records = dns_content['result']
 
     def refresh(self):


### PR DESCRIPTION
According to the doc https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records

API only returns 1 page, and 20 records per page, so when record count greater than 20, some record will missing in local cache, then RecordNotFound occur. This patch changes the page size to 100, the max page size, to avoid the issue.